### PR TITLE
feat(relay-registry): define ContractError enum in errors.rs

### DIFF
--- a/contracts/relay-registry/src/errors.rs
+++ b/contracts/relay-registry/src/errors.rs
@@ -17,8 +17,37 @@
 //!
 //! implementation tracked in GitHub issue
 
-#![allow(unused)]
-
 use soroban_sdk::contracterror;
 
-// implementation tracked in GitHub issue
+/// All error codes returned by the Relay Registry contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    /// Node address is already registered in the registry.
+    AlreadyRegistered = 1,
+
+    /// Node address is not found in the registry.
+    NotRegistered = 2,
+
+    /// Stake amount is below the protocol minimum.
+    InsufficientStake = 3,
+
+    /// Operation requires the node to be in Active status.
+    NodeNotActive = 4,
+
+    /// Operation is blocked because the node has been slashed.
+    NodeSlashed = 5,
+
+    /// Unstake attempted during the stake lock period.
+    StakeLocked = 6,
+
+    /// Caller is not authorized to slash this node.
+    UnauthorizedSlash = 7,
+
+    /// Provided metadata fails validation.
+    InvalidMetadata = 8,
+
+    /// Arithmetic overflow in stake calculation.
+    Overflow = 9,
+}


### PR DESCRIPTION
## feat(relay-registry): define ContractError enum in errors.rs

### Summary
Defines all typed error codes returned by the Relay Registry contract in `contracts/relay-registry/src/errors.rs`. This is a foundational piece required by every contract function.

### Changes
- Added `ContractError` enum annotated with `#[contracterror]`, `#[repr(u32)]`, and full derives (`Copy`, `Clone`, `Debug`, `Eq`, `PartialEq`, `PartialOrd`, `Ord`) as required by Soroban
- Defined 9 variants covering all known error cases:
  - `AlreadyRegistered (1)` — duplicate node registration
  - `NotRegistered (2)` — node not found in registry
  - `InsufficientStake (3)` — stake below protocol minimum
  - `NodeNotActive (4)` — operation requires Active status
  - `NodeSlashed (5)` — operation blocked due to slash
  - `StakeLocked (6)` — unstake attempted during lock period
  - `UnauthorizedSlash (7)` — caller lacks slash authority
  - `InvalidMetadata (8)` — metadata fails validation
  - `Overflow (9)` — arithmetic overflow in stake calculation
- Added `///` doc comments on the enum and every variant

### Notes
- No runtime logic in this file — purely the enum definition as specified
- `panic_with_error!` usage belongs in `lib.rs`, not here

### Checklist
- [x] Branched from `main` as `feat/relay-registry-errors`
- [x] `cargo fmt --all` passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passed
- [x] `stellar contract build` succeeded

Closes #4