### PR TITLE
feat(relay-registry): implement unstake() with lock period enforcement

### DIFF
--- a/contracts/relay-registry/src/lib.rs
+++ b/contracts/relay-registry/src/lib.rs
@@ -27,15 +27,72 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 
 pub mod errors;
 pub mod storage;
 pub mod types;
 
+use crate::errors::ContractError;
+use crate::types::{NodeStatus, StakeEntry};
+
+#[contract]
 pub struct RelayRegistryContract;
 
 #[contractimpl]
 impl RelayRegistryContract {
-    // implementation tracked in GitHub issue
+    /// Initiates unstaking for a registered relay node and records a lock period.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban execution environment.
+    /// - `node_address`: Address of the relay node requesting unstake.
+    /// - `amount`: Amount of stake to unlock.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotRegistered`] if the node is not registered.
+    /// - [`ContractError::NodeSlashed`] if the node has been slashed.
+    /// - [`ContractError::InsufficientStake`] if `amount <= 0` or exceeds current stake.
+    /// - [`ContractError::Overflow`] if arithmetic overflows/underflows.
+    pub fn unstake(env: Env, node_address: Address, amount: i128) -> Result<(), ContractError> {
+        node_address.require_auth();
+
+        let mut node =
+            storage::get_node(&env, &node_address).ok_or(ContractError::NotRegistered)?;
+
+        if node.status == NodeStatus::Slashed {
+            return Err(ContractError::NodeSlashed);
+        }
+
+        if amount <= 0 || amount > node.stake {
+            return Err(ContractError::InsufficientStake);
+        }
+
+        let lock_period = storage::get_stake_lock_period(&env);
+        let unlock_ledger = env
+            .ledger()
+            .sequence()
+            .checked_add(lock_period)
+            .ok_or(ContractError::Overflow)?;
+        let entry = StakeEntry {
+            address: node_address.clone(),
+            unlocks_at: unlock_ledger as u64,
+        };
+        storage::set_pending_unstake(&env, &node_address, &entry);
+
+        let new_stake = node
+            .stake
+            .checked_sub(amount)
+            .ok_or(ContractError::Overflow)?;
+
+        let min_stake = storage::get_min_stake(&env);
+        if new_stake < min_stake {
+            node.status = NodeStatus::Inactive;
+        }
+
+        node.stake = new_stake;
+        storage::set_node(&env, &node_address, &node);
+
+        // TODO: finalize_unstake()
+        Ok(())
+    }
 }

--- a/contracts/relay-registry/src/storage.rs
+++ b/contracts/relay-registry/src/storage.rs
@@ -20,8 +20,96 @@
 //!
 //! implementation tracked in GitHub issue
 
-#![allow(unused)]
-
 use soroban_sdk::{contracttype, Address, Env};
 
-// implementation tracked in GitHub issue
+use crate::types::{RelayNode, StakeEntry};
+
+/// Storage keys used by the relay registry contract.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Registered relay node data keyed by address.
+    RelayNode(Address),
+    /// Total number of registered relay nodes.
+    NodeCount,
+    /// Protocol minimum stake required for active participation.
+    MinStake,
+    /// Number of ledgers to wait before pending unstake can be finalized.
+    StakeLockPeriod,
+    /// Pending unstake entry keyed by node address.
+    PendingUnstake(Address),
+}
+
+/// Returns the relay node for `address`, if one exists.
+pub fn get_node(env: &Env, address: &Address) -> Option<RelayNode> {
+    let key = DataKey::RelayNode(address.clone());
+    env.storage().persistent().get(&key)
+}
+
+/// Persists relay `node` for `address`.
+pub fn set_node(env: &Env, address: &Address, node: &RelayNode) {
+    let key = DataKey::RelayNode(address.clone());
+    env.storage().persistent().set(&key, node);
+}
+
+/// Removes any relay node stored for `address`.
+pub fn remove_node(env: &Env, address: &Address) {
+    let key = DataKey::RelayNode(address.clone());
+    env.storage().persistent().remove(&key);
+}
+
+/// Returns the total number of registered nodes.
+pub fn get_node_count(env: &Env) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::NodeCount)
+        .unwrap_or(0)
+}
+
+/// Increments and persists the total node count by one.
+pub fn increment_node_count(env: &Env) {
+    let next = get_node_count(env).saturating_add(1);
+    env.storage().persistent().set(&DataKey::NodeCount, &next);
+}
+
+/// Returns the configured minimum stake. Defaults to `0` if unset.
+pub fn get_min_stake(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MinStake)
+        .unwrap_or(0)
+}
+
+/// Persists the minimum stake value.
+pub fn set_min_stake(env: &Env, min_stake: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::MinStake, &min_stake);
+}
+
+/// Returns the configured stake lock period (in ledgers). Defaults to `0` if unset.
+pub fn get_stake_lock_period(env: &Env) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::StakeLockPeriod)
+        .unwrap_or(0)
+}
+
+/// Persists the stake lock period in ledgers.
+pub fn set_stake_lock_period(env: &Env, lock_period: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::StakeLockPeriod, &lock_period);
+}
+
+/// Returns the pending unstake entry for `address`, if present.
+pub fn get_pending_unstake(env: &Env, address: &Address) -> Option<StakeEntry> {
+    let key = DataKey::PendingUnstake(address.clone());
+    env.storage().persistent().get(&key)
+}
+
+/// Stores (or overwrites) the pending unstake `entry` for `address`.
+pub fn set_pending_unstake(env: &Env, address: &Address, entry: &StakeEntry) {
+    let key = DataKey::PendingUnstake(address.clone());
+    env.storage().persistent().set(&key, entry);
+}


### PR DESCRIPTION
Closes #7

## Changes
- Implemented `unstake(env, node_address, amount)` in `contracts/relay-registry/src/lib.rs`
- Enforced `node_address.require_auth()`
- Added registration check via `storage::get_node`, returning `ContractError::NotRegistered` when missing
- Blocked unstake for slashed nodes with `ContractError::NodeSlashed`
- Validated unstake amount (`amount > 0` and `amount <= node.stake`), returning `ContractError::InsufficientStake` on invalid input
- Loaded lock period via `storage::get_stake_lock_period`, computed `unlock_ledger`, and stored a pending entry
- Added `// TODO: finalize_unstake()` comment for future withdrawal execution flow
- Deducted stake using checked arithmetic (`checked_sub`) with `ContractError::Overflow` handling
- Loaded `min_stake` and set node status to `Inactive` when post-unstake stake falls below minimum
- Persisted updated node using `storage::set_node`
- Added new storage key: `DataKey::PendingUnstake(Address)` in `contracts/relay-registry/src/storage.rs`
- Added storage helpers:
  - `get_pending_unstake(env: &Env, address: &Address) -> Option<StakeEntry>`
  - `set_pending_unstake(env: &Env, address: &Address, entry: &StakeEntry)`
- Added/updated doc comments for parameters and error behavior

## Testing
- Ran `cargo fmt --all` ✅
- Ran `cargo clippy -p relay-registry --all-targets --all-features -- -D warnings` ✅
- Ran `cargo test -p relay-registry` ✅
- Ran `stellar contract build`
  - `relay_registry.wasm` built successfully ✅
  - Workspace build later failed in unrelated scaffolded contract(s) (`fee-distributor`) ❗

## Notes
- Pending unstake entries overwrite previous entries for the same address, matching issue requirements.
- Token transfer for unstaked amounts is intentionally deferred to future `finalize_unstake()` implementation.
