### PR TITLE
feat(dispute-resolver): implement DataKey enum and storage helpers

### DIFF
--- a/contracts/dispute-resolver/src/storage.rs
+++ b/contracts/dispute-resolver/src/storage.rs
@@ -20,8 +20,86 @@
 //!
 //! implementation tracked in GitHub issue
 
-#![allow(unused)]
+use soroban_sdk::{contracttype, Address, Env};
 
-use soroban_sdk::{contracttype, Env};
+use crate::types::{Dispute, Ruling};
 
-// implementation tracked in GitHub issue
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Dispute(u64),
+    DisputeCount,
+    Ruling(u64),
+    ResolutionWindow,
+    Admin,
+}
+
+/// Load a dispute by its ID. Returns None if not found.
+pub fn get_dispute(env: &Env, dispute_id: u64) -> Option<Dispute> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Dispute(dispute_id))
+}
+
+/// Persist an updated dispute record to storage.
+pub fn set_dispute(env: &Env, dispute_id: u64, dispute: &Dispute) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(dispute_id), dispute);
+}
+
+/// Get the current dispute count. Returns 0 if none exist.
+pub fn get_dispute_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::DisputeCount)
+        .unwrap_or(0)
+}
+
+/// Increment and return the next available dispute ID.
+pub fn get_next_dispute_id(env: &Env) -> u64 {
+    let mut count = get_dispute_count(env);
+    count = count.checked_add(1).expect("dispute count overflow");
+    env.storage().instance().set(&DataKey::DisputeCount, &count);
+    count
+}
+
+/// Load a ruling by the dispute ID. Returns None if no ruling exists.
+pub fn get_ruling(env: &Env, dispute_id: u64) -> Option<Ruling> {
+    env.storage().persistent().get(&DataKey::Ruling(dispute_id))
+}
+
+/// Persist a final ruling to storage.
+pub fn set_ruling(env: &Env, dispute_id: u64, ruling: &Ruling) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Ruling(dispute_id), ruling);
+}
+
+/// Get the resolution window in ledgers.
+pub fn get_resolution_window(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ResolutionWindow)
+        .unwrap_or(0)
+}
+
+/// Set the resolution window in ledgers.
+pub fn set_resolution_window(env: &Env, window_ledgers: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ResolutionWindow, &window_ledgers);
+}
+
+/// Get the admin address.
+pub fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("admin not set")
+}
+
+/// Set the admin address.
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}


### PR DESCRIPTION
## Title: feat(dispute-resolver): implement DataKey enum and storage helpers

### Description
This PR implements all persistent storage read/write helpers for the Dispute Resolver contract in `contracts/dispute-resolver/src/storage.rs`, as requested in Issue #26.

### Changes
- Defined `DataKey` enum with 5 variants:
  - `Dispute(u64)` — keyed by dispute ID, uses `persistent()` storage
  - `DisputeCount` — monotonic ID counter, uses `instance()` storage
  - `Ruling(u64)` — keyed by dispute ID, uses `persistent()` storage
  - `ResolutionWindow` — config, uses `instance()` storage
  - `Admin` — admin address, uses `instance()` storage
- Implemented 10 storage helper functions with doc comments:
  - `get_dispute`, `set_dispute`
  - `get_dispute_count`, `get_next_dispute_id` (IDs start at 1)
  - `get_ruling`, `set_ruling`
  - `get_resolution_window`, `set_resolution_window`
  - `get_admin`, `set_admin`
- Storage tier rules correctly applied:
  - `Dispute(u64)`, `Ruling(u64)` → `env.storage().persistent()`
  - `DisputeCount`, `ResolutionWindow`, `Admin` → `env.storage().instance()`

### Verification
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `stellar contract build` ✅
- `cargo test -p dispute-resolver` ✅

> **Note**: This PR only touches `storage.rs`. The `types.rs` changes (Issue #18) are excluded and will be provided by the contributor working on that issue.

Closes #26
