### PR TITLE
feat(dispute-resolver): implement respond() and resolve() with proof-…

### DIFF
--- a/contracts/dispute-resolver/src/lib.rs
+++ b/contracts/dispute-resolver/src/lib.rs
@@ -13,10 +13,8 @@
 //!
 //! ## Functions
 //! - `raise_dispute(env, initiator, tx_id, proof)` — Submit a new dispute with a relay chain proof
-//! - `respond(env, dispute_id, proof)` — Submit a counter-proof to an open dispute
+//! - `respond(env, respondent, dispute_id, proof)` — Submit a counter-proof to an open dispute
 //! - `resolve(env, dispute_id)` — Resolve a dispute after the evaluation period
-//! - `get_dispute(env, dispute_id)` — Fetch dispute details and current status
-//! - `get_ruling(env, dispute_id)` — Fetch the final ruling for a resolved dispute
 //!
 //! ## See also
 //! - `types.rs` — Data structures (Dispute, DisputeStatus, Ruling, RelayChainProof)
@@ -27,14 +25,14 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 
 pub mod errors;
 pub mod storage;
 pub mod types;
 
 use crate::errors::ContractError;
-use crate::types::{Dispute, DisputeStatus, OptionalRelayChainProof, RelayChainProof};
+use crate::types::{Dispute, DisputeStatus, OptionalRelayChainProof, RelayChainProof, Ruling};
 
 #[contract]
 pub struct DisputeResolverContract;
@@ -96,5 +94,153 @@ impl DisputeResolverContract {
             .publish(("raise_dispute",), (initiator, dispute_id, tx_id));
 
         Ok(dispute_id)
+    }
+
+    /// Submit a counter-proof to an open dispute within the resolution window.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment for the current contract invocation.
+    /// - `respondent`: Address of the party responding to the dispute. Must authorize.
+    /// - `dispute_id`: The unique ID of the dispute to respond to.
+    /// - `proof`: The respondent's cryptographic relay chain proof.
+    ///
+    /// # Errors
+    /// - `ContractError::DisputeNotFound` if no dispute exists for this ID.
+    /// - `ContractError::NotOpen` if the dispute is not in `Open` status.
+    /// - `ContractError::ResolutionWindowExpired` if the response deadline has passed.
+    pub fn respond(
+        env: Env,
+        respondent: Address,
+        dispute_id: u64,
+        proof: RelayChainProof,
+    ) -> Result<(), ContractError> {
+        respondent.require_auth();
+
+        let mut dispute =
+            storage::get_dispute(&env, dispute_id).ok_or(ContractError::DisputeNotFound)?;
+
+        // Only Open disputes can receive a response.
+        if dispute.status != DisputeStatus::Open {
+            return Err(ContractError::NotOpen);
+        }
+
+        // The response window must not have expired.
+        if env.ledger().sequence() as u64 > dispute.resolve_by {
+            return Err(ContractError::ResolutionWindowExpired);
+        }
+
+        dispute.respondent = Some(respondent.clone());
+        dispute.respondent_proof = OptionalRelayChainProof::Some(proof);
+        dispute.status = DisputeStatus::Responded;
+
+        storage::set_dispute(&env, dispute_id, &dispute);
+
+        env.events().publish(("respond",), (respondent, dispute_id));
+
+        Ok(())
+    }
+
+    /// Evaluate both proofs and issue a final ruling for a dispute.
+    ///
+    /// Can be called by anyone once the dispute is in `Responded` status, or by
+    /// anyone after the resolution window expires (ruling goes to initiator by default).
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment for the current contract invocation.
+    /// - `dispute_id`: The unique ID of the dispute to resolve.
+    ///
+    /// # Returns
+    /// The final `Ruling` struct.
+    ///
+    /// # Errors
+    /// - `ContractError::DisputeNotFound` if no dispute exists for this ID.
+    /// - `ContractError::AlreadyResolved` if the dispute is already resolved.
+    /// - `ContractError::ResolutionWindowActive` if the dispute is still Open and the window hasn't expired.
+    /// - `ContractError::NotResponded` if the dispute status is unexpected.
+    pub fn resolve(env: Env, dispute_id: u64) -> Result<Ruling, ContractError> {
+        let mut dispute =
+            storage::get_dispute(&env, dispute_id).ok_or(ContractError::DisputeNotFound)?;
+
+        // Cannot resolve an already-resolved dispute.
+        if dispute.status == DisputeStatus::Resolved {
+            return Err(ContractError::AlreadyResolved);
+        }
+
+        let current_sequence = env.ledger().sequence() as u64;
+
+        // If still Open, check if the window has expired. If not, cannot resolve yet.
+        if dispute.status == DisputeStatus::Open {
+            if current_sequence <= dispute.resolve_by {
+                return Err(ContractError::ResolutionWindowActive);
+            }
+            // Window expired with no response — initiator wins automatically.
+            let ruling = Ruling {
+                dispute_id,
+                winner: dispute.initiator.clone(),
+                loser: dispute.initiator.clone(), // no respondent; loser is a placeholder
+                reason: String::from_str(
+                    &env,
+                    "Respondent failed to respond within the resolution window",
+                ),
+                resolved_at: env.ledger().timestamp(),
+            };
+            dispute.status = DisputeStatus::Resolved;
+            storage::set_dispute(&env, dispute_id, &dispute);
+            storage::set_ruling(&env, dispute_id, &ruling);
+            env.events()
+                .publish(("resolve",), (dispute_id, ruling.winner.clone()));
+            return Ok(ruling);
+        }
+
+        // Must be in Responded state to proceed with proof evaluation.
+        if dispute.status != DisputeStatus::Responded {
+            return Err(ContractError::NotResponded);
+        }
+
+        let respondent = dispute
+            .respondent
+            .clone()
+            .ok_or(ContractError::NotResponded)?;
+
+        // Evaluate by sequence number: lower sequence = originator = wins.
+        let respondent_proof = match &dispute.respondent_proof {
+            OptionalRelayChainProof::Some(p) => p.clone(),
+            OptionalRelayChainProof::None => return Err(ContractError::NotResponded),
+        };
+
+        let (winner, loser, reason) =
+            if dispute.initiator_proof.sequence <= respondent_proof.sequence {
+                (
+                    dispute.initiator.clone(),
+                    respondent.clone(),
+                    String::from_str(
+                        &env,
+                        "Initiator proof has lower or equal sequence; initiator wins",
+                    ),
+                )
+            } else {
+                (
+                    respondent.clone(),
+                    dispute.initiator.clone(),
+                    String::from_str(&env, "Respondent proof has lower sequence; respondent wins"),
+                )
+            };
+
+        let ruling = Ruling {
+            dispute_id,
+            winner: winner.clone(),
+            loser,
+            reason,
+            resolved_at: env.ledger().timestamp(),
+        };
+
+        dispute.status = DisputeStatus::Resolved;
+        storage::set_dispute(&env, dispute_id, &dispute);
+        storage::set_ruling(&env, dispute_id, &ruling);
+
+        env.events()
+            .publish(("resolve",), (dispute_id, ruling.winner.clone()));
+
+        Ok(ruling)
     }
 }


### PR DESCRIPTION
…based ruling

## Title: feat(dispute-resolver): implement respond() and resolve() with proof-based ruling

### Description
This PR implements both `respond()` and `resolve()` in `contracts/dispute-resolver/src/lib.rs` as required by Issue #30.

### Changes

#### `contracts/dispute-resolver/src/lib.rs`

**`respond(env, respondent, dispute_id, proof)`**
- Calls `respondent.require_auth()`
- Returns `ContractError::DisputeNotFound` if dispute doesn't exist
- Returns `ContractError::NotOpen` if dispute is not in `Open` status
- Returns `ContractError::ResolutionWindowExpired` if deadline has passed
- Sets `dispute.respondent`, `dispute.respondent_proof`, `dispute.status = Responded`
- Persists updated dispute and emits `("respond",)` event

**`resolve(env, dispute_id)`**
- Returns `ContractError::DisputeNotFound` if dispute doesn't exist
- Returns `ContractError::AlreadyResolved` if already resolved
- Returns `ContractError::ResolutionWindowActive` if still Open within the deadline → cannot resolve yet
- If Open and deadline expired → rules in favour of initiator automatically (no respondent)
- If `Responded` → evaluates by sequence number precedence:
  - Lower sequence = originator = wins
  - Equal sequences → initiator wins (tie-break rule)
- Builds `Ruling` struct, sets `dispute.status = Resolved`, persists both
- Emits `("resolve",)` event
- Returns `Ok(ruling)`

### Verification
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `stellar contract build` ✅ (`raise_dispute`, `respond`, `resolve` all exported in WASM)
- `cargo test -p dispute-resolver` ✅

> **Note**: This PR only commits `lib.rs`. The `types.rs` (Issue #18) and `errors.rs` (Issue #27) stubs are used locally for compilation but not committed, and will be provided by the respective contributors.

Closes #30
