### PR TITLE
feat(fee-distributor): implement calculate_fee() with basis-point for…

### DIFF
--- a/contracts/fee-distributor/src/lib.rs
+++ b/contracts/fee-distributor/src/lib.rs
@@ -27,16 +27,53 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl};
+use soroban_sdk::{contract, contractimpl, Env};
 
 pub mod errors;
 pub mod storage;
 pub mod types;
+
+use crate::errors::ContractError;
 
 #[contract]
 pub struct FeeDistributorContract;
 
 #[contractimpl]
 impl FeeDistributorContract {
-    // implementation tracked in GitHub issue
+    /// Calculate the total fee for a given batch of transactions.
+    ///
+    /// This is a pure calculation function that reads the configured fee rate
+    /// and returns the total fee amount. No storage is written.
+    ///
+    /// # Formula
+    /// `fee = (batch_size as i128) * (fee_rate_bps as i128) / 10000`
+    ///
+    /// # Example
+    /// - With `fee_rate_bps = 50` (0.5%) and `batch_size = 200`:
+    ///   `fee = 200 * 50 / 10000 = 1`
+    /// - With `fee_rate_bps = 500` (5%) and `batch_size = 1000`:
+    ///   `fee = 1000 * 500 / 10000 = 50`
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `batch_size`: Number of transactions in the settled batch.
+    ///
+    /// # Errors
+    /// - `ContractError::InvalidBatchSize` if `batch_size` is zero.
+    /// - `ContractError::Overflow` if the calculation overflows.
+    pub fn calculate_fee(env: Env, batch_size: u32) -> Result<i128, ContractError> {
+        if batch_size == 0 {
+            return Err(ContractError::InvalidBatchSize);
+        }
+
+        let config = storage::get_fee_config(&env);
+
+        let total = (batch_size as i128)
+            .checked_mul(config.fee_rate_bps as i128)
+            .ok_or(ContractError::Overflow)?;
+
+        let fee = total.checked_div(10000).ok_or(ContractError::Overflow)?;
+
+        Ok(fee)
+    }
 }


### PR DESCRIPTION
…mula



## Title: feat(fee-distributor): implement calculate_fee() with basis-point formula
## Closes #14

### Description
This PR implements the `calculate_fee()` function in `contracts/fee-distributor/src/lib.rs`, safely calculating relay fees using basis points as described in Issue #14.

### Changes made
- Implemented `calculate_fee(env: Env, batch_size: u32) -> Result<i128, ContractError>` inside `FeeDistributorContract`.
- Added strict parameter bound checking allowing only batch sizes `> 0`, returning `ContractError::InvalidBatchSize` otherwise.
- Successfully extracted `fee_rate_bps` via `storage::get_fee_config(&env)`.
- Applied standard basis-point formula computations safely utilizing integer `checked_mul` and `checked_div`.
- Automatically bubble `ContractError::Overflow` if Math functions overflow during calculation.
- Ensured this strictly remains a pure view operation—no writes to persistent storage exist.
- Maintained highest-quality inline mathematical documentation as requested including calculation examples.

### Verification
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `stellar contract build` ✅
- `cargo test -p fee-distributor` ✅

*(Note: `lib.rs` is solely committed here to prevent `types.rs`, `errors.rs`, etc. overwriting changes from other pending dependent branches)*
