### PR TITLE
feat(fee-distributor): implement get_earnings() and set_fee_rate()

### DIFF
--- a/contracts/fee-distributor/src/lib.rs
+++ b/contracts/fee-distributor/src/lib.rs
@@ -187,4 +187,49 @@ impl FeeDistributorContract {
         // TODO: SAC transfer payout to relay_address
         Ok(payout)
     }
+
+    /// Retrieve the cumulative earnings record for a relay node.
+    ///
+    /// This is a read-only view function that returns the total earned,
+    /// total claimed, and currently unclaimed fees for the given relay node.
+    /// If the node has no earnings history, it returns a zeroed record.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `relay_address`: Address of the relay node.
+    ///
+    /// # Returns
+    /// An `EarningsRecord` containing the relay node's fee history.
+    pub fn get_earnings(env: Env, relay_address: Address) -> crate::types::EarningsRecord {
+        storage::get_earnings(&env, &relay_address)
+    }
+
+    /// Update the protocol fee rate.
+    ///
+    /// This function can only be called by the configured admin address.
+    /// The fee rate is specified in basis points (bps), where 10000 = 100%.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `new_fee_rate_bps`: The new fee rate in basis points (1 to 10000).
+    ///
+    /// # Errors
+    /// - Auth error if caller is not the admin.
+    /// - `ContractError::InvalidFeeRate` if the rate is 0 or greater than 10000.
+    pub fn set_fee_rate(env: Env, new_fee_rate_bps: u32) -> Result<(), ContractError> {
+        let mut config = storage::get_fee_config(&env);
+
+        config.admin.require_auth();
+
+        if new_fee_rate_bps == 0 || new_fee_rate_bps > 10_000 {
+            return Err(ContractError::InvalidFeeRate);
+        }
+
+        config.fee_rate_bps = new_fee_rate_bps;
+        storage::set_fee_config(&env, &config);
+
+        env.events().publish(("set_fee_rate",), (new_fee_rate_bps,));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Title: feat(fee-distributor): implement get_earnings() and set_fee_rate()
## Closes #17

### Description
This PR implements `get_earnings()` and `set_fee_rate()` functions within `contracts/fee-distributor/src/lib.rs`.
- `get_earnings()`: Provides a public and read-only method that allows anyone to inspect the earnings of a relay node directly in the smart contract by addressing `storage::get_earnings()`. If the user does not have a previously initialized history record, a zeroed default output is returned seamlessly.
- `set_fee_rate()`: An admin-only mutation function that checks out the contract admin property properly, evaluates that the `new_fee_rate_bps` payload value sits strictly between 1 - 10,000 basis points exclusive of zeroes, and updates the local storage properly using `storage::set_fee_config()`. Finally, it emits a `set_fee_rate` event payload up the chain.

### Changes made
- Implemented `get_earnings(env: Env, relay_address: Address) -> EarningsRecord` in `FeeDistributorContract`.
- Implemented `set_fee_rate(env: Env, new_fee_rate_bps: u32) -> Result<(), ContractError>` in `FeeDistributorContract` ensuring strict `ContractError::InvalidFeeRate` errors.
- Documented both functions extensively.

### Verification
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `stellar contract build` ✅
- `cargo test -p fee-distributor` ✅

*(Note: As with previous patches on this layer, I am **only** pushing the logic changes in `lib.rs` ignoring local stubs for `storage`, `types`, etc., guarding upstream models against merge conflicts).*
