### PR TITLE
feat(observability): standardize event schemas across all contracts

### DIFF
--- a/contracts/dispute-resolver/src/lib.rs
+++ b/contracts/dispute-resolver/src/lib.rs
@@ -95,8 +95,13 @@ impl DisputeResolverContract {
         storage::set_dispute_by_tx(&env, &tx_id, dispute_id);
 
         // Emit event for off-chain indexers.
-        env.events()
-            .publish(("raise_dispute",), (initiator, dispute_id, tx_id));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "dispute_resolver"),
+                soroban_sdk::Symbol::new(&env, "raise"),
+            ),
+            (initiator, dispute_id, tx_id),
+        );
 
         Ok(dispute_id)
     }
@@ -140,7 +145,13 @@ impl DisputeResolverContract {
 
         storage::set_dispute(&env, dispute_id, &dispute);
 
-        env.events().publish(("respond",), (respondent, dispute_id));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "dispute_resolver"),
+                soroban_sdk::Symbol::new(&env, "respond"),
+            ),
+            (respondent, dispute_id),
+        );
 
         Ok(())
     }
@@ -192,8 +203,13 @@ impl DisputeResolverContract {
             dispute.status = DisputeStatus::Resolved;
             storage::set_dispute(&env, dispute_id, &dispute);
             storage::set_ruling(&env, dispute_id, &ruling);
-            env.events()
-                .publish(("resolve",), (dispute_id, ruling.winner.clone()));
+            env.events().publish(
+                (
+                    soroban_sdk::Symbol::new(&env, "dispute_resolver"),
+                    soroban_sdk::Symbol::new(&env, "resolve"),
+                ),
+                (dispute_id, ruling.winner.clone(), ruling.loser.clone()),
+            );
             return Ok(ruling);
         }
 
@@ -275,8 +291,13 @@ impl DisputeResolverContract {
         storage::set_dispute(&env, dispute_id, &dispute);
         storage::set_ruling(&env, dispute_id, &ruling);
 
-        env.events()
-            .publish(("resolve",), (dispute_id, ruling.winner.clone()));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "dispute_resolver"),
+                soroban_sdk::Symbol::new(&env, "resolve"),
+            ),
+            (dispute_id, ruling.winner.clone(), ruling.loser.clone()),
+        );
 
         Ok(ruling)
     }

--- a/contracts/dispute-resolver/test_snapshots/test/test_resolve_both_valid_initiator_wins.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test/test_resolve_both_valid_initiator_wins.1.json
@@ -708,7 +708,10 @@
           "v0": {
             "topics": [
               {
-                "string": "resolve"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "resolve"
               }
             ],
             "data": {
@@ -718,6 +721,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }

--- a/contracts/dispute-resolver/test_snapshots/test/test_resolve_both_valid_respondent_wins.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test/test_resolve_both_valid_respondent_wins.1.json
@@ -708,7 +708,10 @@
           "v0": {
             "topics": [
               {
-                "string": "resolve"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "resolve"
               }
             ],
             "data": {
@@ -718,6 +721,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             }

--- a/contracts/dispute-resolver/test_snapshots/test_raise_dispute_auto_increment_id.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test_raise_dispute_auto_increment_id.1.json
@@ -785,7 +785,10 @@
           "v0": {
             "topics": [
               {
-                "string": "raise_dispute"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "raise"
               }
             ],
             "data": {

--- a/contracts/dispute-resolver/test_snapshots/test_resolve_initiator_wins_lower_sequence.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test_resolve_initiator_wins_lower_sequence.1.json
@@ -708,7 +708,10 @@
           "v0": {
             "topics": [
               {
-                "string": "resolve"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "resolve"
               }
             ],
             "data": {
@@ -718,6 +721,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }

--- a/contracts/dispute-resolver/test_snapshots/test_resolve_no_response_expired.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test_resolve_no_response_expired.1.json
@@ -595,13 +595,19 @@
           "v0": {
             "topics": [
               {
-                "string": "resolve"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "resolve"
               }
             ],
             "data": {
               "vec": [
                 {
                   "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"

--- a/contracts/dispute-resolver/test_snapshots/test_resolve_respondent_wins_lower_sequence.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test_resolve_respondent_wins_lower_sequence.1.json
@@ -708,7 +708,10 @@
           "v0": {
             "topics": [
               {
-                "string": "resolve"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "resolve"
               }
             ],
             "data": {
@@ -718,6 +721,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             }

--- a/contracts/dispute-resolver/test_snapshots/test_resolve_tie_initiator_wins.1.json
+++ b/contracts/dispute-resolver/test_snapshots/test_resolve_tie_initiator_wins.1.json
@@ -708,7 +708,10 @@
           "v0": {
             "topics": [
               {
-                "string": "resolve"
+                "symbol": "dispute_resolver"
+              },
+              {
+                "symbol": "resolve"
               }
             ],
             "data": {
@@ -718,6 +721,9 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }

--- a/contracts/fee-distributor/src/lib.rs
+++ b/contracts/fee-distributor/src/lib.rs
@@ -205,8 +205,16 @@ impl FeeDistributorContract {
         storage::set_fee_entry(&env, batch_id, &entry);
 
         env.events().publish(
-            ("distribute",),
-            (relay_address.clone(), batch_id, relay_payout),
+            (
+                soroban_sdk::Symbol::new(&env, "fee_distributor"),
+                soroban_sdk::Symbol::new(&env, "distribute"),
+            ),
+            (
+                relay_address.clone(),
+                batch_id,
+                relay_payout,
+                treasury_share,
+            ),
         );
 
         // TODO: SAC transfer treasury_share to treasury
@@ -248,8 +256,13 @@ impl FeeDistributorContract {
 
         storage::set_earnings(&env, &relay_address, &record);
 
-        env.events()
-            .publish(("claim",), (relay_address.clone(), payout));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "fee_distributor"),
+                soroban_sdk::Symbol::new(&env, "claim"),
+            ),
+            (relay_address.clone(), payout),
+        );
 
         // TODO: SAC transfer payout to relay_address
         Ok(payout)
@@ -295,7 +308,13 @@ impl FeeDistributorContract {
         config.fee_rate_bps = new_fee_rate_bps;
         storage::set_fee_config(&env, &config);
 
-        env.events().publish(("set_fee_rate",), (new_fee_rate_bps,));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "fee_distributor"),
+                soroban_sdk::Symbol::new(&env, "set_fee_rate"),
+            ),
+            (new_fee_rate_bps,),
+        );
 
         Ok(())
     }

--- a/contracts/fee-distributor/test_snapshots/test/test_claim_auth_required.2.json
+++ b/contracts/fee-distributor/test_snapshots/test/test_claim_auth_required.2.json
@@ -325,7 +325,10 @@
           "v0": {
             "topics": [
               {
-                "string": "distribute"
+                "symbol": "fee_distributor"
+              },
+              {
+                "symbol": "distribute"
               }
             ],
             "data": {
@@ -340,6 +343,12 @@
                   "i128": {
                     "hi": 0,
                     "lo": 1
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
                   }
                 }
               ]

--- a/contracts/relay-registry/src/lib.rs
+++ b/contracts/relay-registry/src/lib.rs
@@ -188,13 +188,22 @@ impl RelayRegistryContract {
             address: node_address.clone(),
             stake: 0,
             status: NodeStatus::Inactive,
-            metadata,
+            metadata: metadata.clone(),
             registered_at: timestamp,
             last_active: timestamp,
         };
 
         storage::set_node(&env, &node_address, &node);
         storage::increment_node_count(&env);
+
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "relay_registry"),
+                soroban_sdk::Symbol::new(&env, "register"),
+            ),
+            (node_address.clone(), metadata),
+        );
+
         Ok(())
     }
 
@@ -226,8 +235,13 @@ impl RelayRegistryContract {
 
         storage::set_node(&env, &node_address, &node);
 
-        env.events()
-            .publish(("update_metadata",), (node_address.clone(),));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "relay_registry"),
+                soroban_sdk::Symbol::new(&env, "update_metadata"),
+            ),
+            (node_address.clone(),),
+        );
 
         Ok(())
     }
@@ -280,6 +294,14 @@ impl RelayRegistryContract {
 
         storage::set_node(&env, &node_address, &node);
 
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "relay_registry"),
+                soroban_sdk::Symbol::new(&env, "stake"),
+            ),
+            (node_address.clone(), amount),
+        );
+
         Ok(())
     }
 
@@ -327,6 +349,15 @@ impl RelayRegistryContract {
         token.transfer(&env.current_contract_address(), &node_address, &amount);
 
         storage::set_node(&env, &node_address, &node);
+
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "relay_registry"),
+                soroban_sdk::Symbol::new(&env, "unstake"),
+            ),
+            (node_address.clone(), amount, unlock_after),
+        );
+
         Ok(node)
     }
 
@@ -344,7 +375,7 @@ impl RelayRegistryContract {
     /// - `ContractError::NotRegistered` if the node is not in the registry.
     /// - `ContractError::NodeSlashed` if the node is already slashed.
     /// - (Auth) Soroban will automatically panic if the caller is not the `Admin`.
-    pub fn slash(env: Env, node_address: Address, reason: String) -> Result<(), ContractError> {
+    pub fn slash(env: Env, node_address: Address, _reason: String) -> Result<(), ContractError> {
         require_council_auth(&env);
 
         let mut node =
@@ -356,6 +387,7 @@ impl RelayRegistryContract {
         }
 
         // Apply penalty: total loss of stake
+        let slashed_amount = node.stake;
         node.stake = 0;
         node.status = NodeStatus::Slashed;
         node.last_active = env.ledger().timestamp();
@@ -367,8 +399,13 @@ impl RelayRegistryContract {
         storage::set_node(&env, &node_address, &node);
 
         // Emit an event so the slashing reason is auditable on-chain.
-        env.events()
-            .publish(("slash",), (node_address.clone(), reason));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "relay_registry"),
+                soroban_sdk::Symbol::new(&env, "slash"),
+            ),
+            (node_address.clone(), slashed_amount),
+        );
 
         Ok(())
     }

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -137,7 +137,13 @@ impl TreasuryContract {
         let token = token::Client::new(&env, &token_address);
         token.transfer(&from, &env.current_contract_address(), &amount);
 
-        env.events().publish(("deposit",), (from.clone(), amount));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "treasury"),
+                soroban_sdk::Symbol::new(&env, "deposit"),
+            ),
+            (from.clone(), amount),
+        );
 
         Ok(())
     }
@@ -187,7 +193,7 @@ impl TreasuryContract {
             amount,
             actor: env.current_contract_address(), // We record the contract executing since it's a multisig operation
             recipient: Some(to.clone()),
-            memo,
+            memo: memo.clone(),
             ledger: env.ledger().sequence() as u64,
         };
         storage::set_entry(&env, entry);
@@ -195,7 +201,13 @@ impl TreasuryContract {
         let token = token::Client::new(&env, &storage::get_token_address(&env));
         token.transfer(&env.current_contract_address(), &to, &amount);
 
-        env.events().publish(("withdraw",), (to.clone(), amount));
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "treasury"),
+                soroban_sdk::Symbol::new(&env, "withdraw"),
+            ),
+            (to.clone(), amount, memo),
+        );
 
         Ok(())
     }
@@ -275,6 +287,14 @@ impl TreasuryContract {
         // TODO: Map program_id to its recipient address and transfer SAC token.
         // let token = token::Client::new(&env, &storage::get_token_address(&env));
         // token.transfer(&env.current_contract_address(), &program_recipient_address, &amount);
+
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "treasury"),
+                soroban_sdk::Symbol::new(&env, "allocate"),
+            ),
+            (program_id, amount),
+        );
 
         Ok(())
     }

--- a/contracts/treasury/test_snapshots/test/test_deposit_logs_entry_and_emits_event.1.json
+++ b/contracts/treasury/test_snapshots/test/test_deposit_logs_entry_and_emits_event.1.json
@@ -788,7 +788,10 @@
           "v0": {
             "topics": [
               {
-                "string": "deposit"
+                "symbol": "treasury"
+              },
+              {
+                "symbol": "deposit"
               }
             ],
             "data": {


### PR DESCRIPTION
### Summary
Establishes a uniform event schema for all `env.events().publish()` calls across the four StellarConduit contracts to enable consistent off-chain indexing, analytics, and alerting.

### Changes
All events now follow the standardized format:
rust
(Symbol::new(&env, "contract_name"), Symbol::new(&env, "action_name")), (payload...)

#### Relay Registry
- `register` → `("relay_registry", "register"), (node_address, metadata)`
- `stake` → `("relay_registry", "stake"), (node_address, amount)`
- `unstake` → `("relay_registry", "unstake"), (node_address, amount, unlocks_at)`
- `slash` → `("relay_registry", "slash"), (node_address, slashed_amount)`
- `update_metadata` → `("relay_registry", "update_metadata"), (node_address,)`

#### Fee Distributor
- `distribute` → `("fee_distributor", "distribute"), (relay_address, batch_id, payout, treasury_share)`
- `claim` → `("fee_distributor", "claim"), (relay_address, amount)`
- `set_fee_rate` → `("fee_distributor", "set_fee_rate"), (new_rate,)`

#### Dispute Resolver
- `raise_dispute` → `("dispute_resolver", "raise"), (initiator, dispute_id, tx_id)`
- `respond` → `("dispute_resolver", "respond"), (respondent, dispute_id)`
- `resolve` → `("dispute_resolver", "resolve"), (dispute_id, winner, loser)`

#### Treasury
- `deposit` → `("treasury", "deposit"), (from, amount)`
- `withdraw` → `("treasury", "withdraw"), (to, amount, memo)`
- `allocate` → `("treasury", "allocate"), (program_id, amount)`

### Testing
- ✅ All 103 tests pass
- ✅ `cargo fmt --all` 
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ Test snapshots updated automatically

### Impact
- Off-chain indexers can now use uniform parsing logic
- Contract identification via prefix enables easy event filtering
- Complete event payloads improve observability and debugging

### Closes: #80 