### PR TITLE
feat(relay-registry): implement get_node() and is_active() query func…

### DIFF
--- a/contracts/relay-registry/src/lib.rs
+++ b/contracts/relay-registry/src/lib.rs
@@ -451,11 +451,37 @@ impl RelayRegistryContract {
 
         Ok(())
     }
-
+    /// Retrieves a registered relay node's details.
+    ///
+    /// This is a view-only function that returns the `RelayNode` struct
+    /// associated with the given address. It does not require authorization.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment for the current contract invocation.
+    /// - `address`: The Stellar account address of the relay node to lookup.
+    ///
+    /// # Returns
+    /// - `Ok(RelayNode)`: The registered node details if found.
+    ///
+    /// # Errors
+    /// - `ContractError::NotRegistered`: If the address is not registered in the registry.
     pub fn get_node(env: Env, address: Address) -> Result<RelayNode, ContractError> {
         storage::get_node(&env, &address).ok_or(ContractError::NotRegistered)
     }
 
+    /// Checks if a relay node is currently active.
+    ///
+    /// This is a view-only function that returns true if the given address is
+    /// a registered relay node with a status of `NodeStatus::Active`. It does not
+    /// require authorization. This function never errors; it returns false for any unknown or inactive address.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment for the current contract invocation.
+    /// - `address`: The Stellar account address of the relay node to check.
+    ///
+    /// # Returns
+    /// - `true`: If the node exists and its status is `NodeStatus::Active`.
+    /// - `false`: If the node is not registered, or its status is not active.
     pub fn is_active(env: Env, address: Address) -> bool {
         matches!(
             storage::get_node(&env, &address).map(|n| n.status),


### PR DESCRIPTION
…tions


# feat(relay-registry): Implement get_node() and is_active() functions

## Objective
Implements the view-only query functions `get_node()` and `is_active()` for the Relay Registry contract, as per Issue #9. 
These functions allow external callers to query relay node state without modifying it. The required `///` doc comments have been added indicating parameters, errors, and return values.

## Changes
- Add documentation comments to `get_node()` and `is_active()` in `contracts/relay-registry/src/lib.rs`.
- Ensure functions are marked `pub` and don't enforce authorization, conforming exactly to the issue's specification for view-only functions.

## Validation
- ✅ `cargo fmt --all` executed successfully.
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` passed cleanly.
- ✅ `stellar contract build` successfully compiled the `.wasm`.
- ✅ `cargo test -p relay-registry` executed and all tests passed (9/9).

Closes #9
