### PR TITLE
feat(treasury): implement spending program lifecycle management

### DIFF
--- a/contracts/treasury/src/errors.rs
+++ b/contracts/treasury/src/errors.rs
@@ -47,4 +47,7 @@ pub enum ContractError {
 
     /// Council config is invalid (threshold > members, etc.).
     InvalidCouncilConfig = 14,
+
+    /// Program name length is out of bounds.
+    InvalidProgramName = 15,
 }

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -34,7 +34,7 @@ pub mod storage;
 pub mod types;
 
 use crate::errors::ContractError;
-use crate::types::{AdminCouncil, EntryKind, TreasuryEntry, TreasuryStats};
+use crate::types::{AdminCouncil, EntryKind, SpendingProgram, TreasuryEntry, TreasuryStats};
 
 fn require_council_auth(env: &Env) {
     let council = storage::get_admin_council(env);
@@ -210,6 +210,101 @@ impl TreasuryContract {
         );
 
         Ok(())
+    }
+
+    /// Create a new spending program with a specified budget.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `name`: Name of the program (3-64 chars).
+    /// - `budget`: Initial budget for the program. Must be > 0.
+    pub fn create_program(env: Env, name: String, budget: i128) -> Result<u64, ContractError> {
+        require_council_auth(&env);
+
+        if budget <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        if name.len() < 3 || name.len() > 64 {
+            return Err(ContractError::InvalidProgramName);
+        }
+
+        let program_id = storage::increment_program_count(&env);
+
+        let program = SpendingProgram {
+            program_id,
+            budget,
+            spent: 0,
+            active: true,
+            name: name.clone(),
+        };
+
+        storage::set_spending_program(&env, program_id, program);
+
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "treasury"),
+                soroban_sdk::Symbol::new(&env, "create_program"),
+            ),
+            (program_id, name, budget),
+        );
+
+        Ok(program_id)
+    }
+
+    /// Update the budget of an existing spending program.
+    pub fn update_program_budget(
+        env: Env,
+        program_id: u64,
+        new_budget: i128,
+    ) -> Result<(), ContractError> {
+        require_council_auth(&env);
+
+        let mut program = storage::get_spending_program(&env, program_id)
+            .ok_or(ContractError::ProgramNotFound)?;
+
+        if new_budget < program.spent {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        program.budget = new_budget;
+        storage::set_spending_program(&env, program_id, program);
+
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "treasury"),
+                soroban_sdk::Symbol::new(&env, "update_budget"),
+            ),
+            (program_id, new_budget),
+        );
+
+        Ok(())
+    }
+
+    /// Deactivate a spending program.
+    pub fn deactivate_program(env: Env, program_id: u64) -> Result<(), ContractError> {
+        require_council_auth(&env);
+
+        let mut program = storage::get_spending_program(&env, program_id)
+            .ok_or(ContractError::ProgramNotFound)?;
+
+        program.active = false;
+        storage::set_spending_program(&env, program_id, program);
+
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "treasury"),
+                soroban_sdk::Symbol::new(&env, "deactivate_program"),
+            ),
+            (program_id,),
+        );
+
+        Ok(())
+    }
+
+    /// Get details of a spending program.
+    pub fn get_program(env: Env, program_id: u64) -> Result<SpendingProgram, ContractError> {
+        storage::get_spending_program(&env, program_id).ok_or(ContractError::ProgramNotFound)
     }
 
     /// Allocate treasury funds to a spending program (admin only).

--- a/contracts/treasury/src/storage.rs
+++ b/contracts/treasury/src/storage.rs
@@ -38,6 +38,8 @@ pub enum DataKey {
     EntryCount,
     /// A TreasuryEntry keyed by entry_id.
     Entry(u64),
+    /// Total number of created programs.
+    ProgramCount,
     /// Allocation records keyed by program name.
     Allocation(String),
     /// A SpendingProgram keyed by program_id.
@@ -111,6 +113,22 @@ pub fn get_spending_program(env: &Env, program_id: u64) -> Option<SpendingProgra
     env.storage()
         .persistent()
         .get(&DataKey::SpendingProgram(program_id))
+}
+
+pub fn get_program_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ProgramCount)
+        .unwrap_or(0)
+}
+
+pub fn increment_program_count(env: &Env) -> u64 {
+    let count = get_program_count(env);
+    let next_id = count.checked_add(1).expect("program count overflow");
+    env.storage()
+        .instance()
+        .set(&DataKey::ProgramCount, &next_id);
+    next_id
 }
 
 /// Persist a spending program.


### PR DESCRIPTION
# feat(treasury): Implement spending program lifecycle management

## Objective
Add functions to `contracts/treasury/src/lib.rs` to create, modify, deactivate, and query spending programs correctly. This implements Issue #76.

## Changes
- **DataKey/Storage**: Added `DataKey::ProgramCount` logic to `storage.rs` for tracking auto-incrementing program IDs.
- **Errors**: Added `InvalidProgramName` error for out-of-bounds name length.
- **Functions**: Implement `create_program`, `update_program_budget`, `deactivate_program`, and `get_program` in `lib.rs` for the `TreasuryContract`.
- **Validation**:
  - Requires admin council auth for mutations (`create_program`, `update_program_budget`, `deactivate_program`).
  - Budget must be > 0.
  - Name length between 3 and 64 characters.
  - Updates to budgets validate new budget >= already spent funds.
- **Events**: Added required lifecycle events (`create_program`, `update_budget`, `deactivate_program`).

## Verification
- ✅ `cargo fmt --all`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo test -p treasury`
- ✅ `stellar contract build`

Closes #76
