### PR TITLE
chore(scripts): add contract deployment and governance setup scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,28 @@ jobs:
               exit 1
             fi
           done <<< "$wasms"
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Stellar CLI
+        uses: stellar/stellar-cli@v23.0.1
+
+      - name: Run Integration Tests
+        run: |
+          chmod +x scripts/*.sh
+          ./scripts/run-integration-tests.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ ehthumbs.db
 Thumbs.db
 # Local issue tracking (do not push)
 docs/issues/
+
+# Scripts environment files
+/scripts/*.env
+

--- a/contracts/relay-registry/src/lib.rs
+++ b/contracts/relay-registry/src/lib.rs
@@ -121,6 +121,8 @@ impl RelayRegistryContract {
     pub fn initialize(
         env: Env,
         council: AdminCouncil,
+        token_address: Address,
+        treasury_address: Address,
         min_stake: i128,
         stake_lock_period: u32,
     ) -> Result<(), ContractError> {
@@ -149,6 +151,8 @@ impl RelayRegistryContract {
 
         // Persist config
         storage::set_admin_council(&env, &council);
+        storage::set_token_address(&env, &token_address);
+        let _ = treasury_address; // Stored in fee-distributor, accepted here for signature alignment
         storage::set_min_stake(&env, min_stake);
         storage::set_stake_lock_period(&env, stake_lock_period);
 

--- a/contracts/relay-registry/tests/relay-registry-test.rs
+++ b/contracts/relay-registry/tests/relay-registry-test.rs
@@ -25,7 +25,13 @@ fn setup<'a>() -> (Env, RelayRegistryContractClient<'a>, Address) {
 
     let token_address = Address::generate(&env);
     let treasury_address = Address::generate(&env);
-    client.initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
+    client.initialize(
+        &council,
+        &token_address,
+        &treasury_address,
+        &100i128,
+        &10u32,
+    );
     (env, client, admin)
 }
 
@@ -169,7 +175,13 @@ fn test_update_metadata_auth_required_clean() {
 
     let token_address = Address::generate(&env);
     let treasury_address = Address::generate(&env);
-    client.initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
+    client.initialize(
+        &council,
+        &token_address,
+        &treasury_address,
+        &100i128,
+        &10u32,
+    );
 
     let node_addr = Address::generate(&env);
 

--- a/contracts/relay-registry/tests/relay-registry-test.rs
+++ b/contracts/relay-registry/tests/relay-registry-test.rs
@@ -23,7 +23,9 @@ fn setup<'a>() -> (Env, RelayRegistryContractClient<'a>, Address) {
         threshold: 1,
     };
 
-    client.initialize(&council, &100i128, &10u32);
+    let token_address = Address::generate(&env);
+    let treasury_address = Address::generate(&env);
+    client.initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
     (env, client, admin)
 }
 
@@ -165,11 +167,9 @@ fn test_update_metadata_auth_required_clean() {
         threshold: 1,
     };
 
-    // Hack: to initialize and register without `mock_all_auths`,
-    // we just don't call `mock_all_auths` and let it panic on `initialize` because
-    // `require_auth` isn't called in `initialize`!
-    // Wait, `initialize` does not call `require_auth`!
-    client.initialize(&council, &100i128, &10u32);
+    let token_address = Address::generate(&env);
+    let treasury_address = Address::generate(&env);
+    client.initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
 
     let node_addr = Address::generate(&env);
 

--- a/contracts/treasury/Cargo.toml
+++ b/contracts/treasury/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -112,19 +112,35 @@ stellar keys fund testnet-deployer --network testnet
 stellar account show testnet-deployer --network testnet
 ```
 
-### 2. (Optional) Deploy Using the Helper Script
+### 2. Automated Deployment Using Helper Scripts
 
-If you prefer to use the project-provided helper script:
+You can build, deploy, initialize, and wire all contracts using the project-provided helper scripts:
 
-```bash
-# Deploy the relay registry
-bash scripts/deploy-testnet.sh relay-registry
+1. **Configure Environment:** Copy the template configuration file and customize your values:
+   ```bash
+   cp scripts/.env.example scripts/.env
+   # Edit scripts/.env to configure the target NETWORK, ADMIN keys, and RPC endpoints.
+   ```
+2. **Deploy All Contracts:** Run the deployment script to compile all contracts to WASM and deploy them to the target network in the correct dependency order:
+   ```bash
+   bash scripts/deploy-all.sh
+   ```
+   This script writes the deployed contract IDs to `scripts/.deployed-addresses.env`. If `SAC_TOKEN_ADDRESS` is left blank on a local or testnet network, it will automatically deploy and wrap the native XLM token.
+3. **Initialize All Contracts:** Run the initialization script to configure the contract parameters and cross-contract address references automatically:
+   ```bash
+   bash scripts/initialize-all.sh
+   ```
+4. **Register and Stake a Relay Node:** Use the registration script to easily onboard a new node:
+   ```bash
+   bash scripts/register-relay-node.sh <NODE_ADDRESS_OR_SECRET> <STAKE_AMOUNT> [REGION]
+   ```
+5. **Run Local Sandbox Integration Tests:** Run the E2E integration tests inside a local Stellar Quickstart Docker container sandbox:
+   ```bash
+   bash scripts/run-integration-tests.sh
+   ```
 
-# Deploy all contracts
-bash scripts/deploy-testnet.sh all
-```
+The remainder of this section documents the **equivalent manual steps** using the `stellar` CLI directly.
 
-The remainder of this section documents the **equivalent manual steps** using `stellar` directly.
 
 ### 3. Manual Deployment (Topological Order)
 

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,7 @@
+# Copy this to scripts/.env and fill in your values
+NETWORK=testnet                           # testnet | mainnet | local
+ADMIN_SECRET_KEY=S...                    # Ed25519 secret key for the admin account
+ADMIN_ADDRESS=G...                       # Corresponding public address
+SAC_TOKEN_ADDRESS=C...                   # Deployed SAC contract address (XLM or custom). If empty on local/testnet, deploy-all.sh will auto-deploy/wrap native XLM.
+RPC_URL=https://soroban-testnet.stellar.org
+HORIZON_URL=https://horizon-testnet.stellar.org

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy-all.sh
+# StellarConduit Contracts — Automated Deployment Script
+# =============================================================================
+set -euo pipefail
+
+# Load config
+SCRIPT_DIR=$(dirname "$0")
+ENV_FILE="$SCRIPT_DIR/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Error: $ENV_FILE not found. Please copy .env.example to .env and configure it." >&2
+  exit 1
+fi
+
+source "$ENV_FILE"
+
+# Validate required variables
+if [ -z "${NETWORK:-}" ]; then
+  echo "Error: NETWORK must be set in .env" >&2
+  exit 1
+fi
+if [ -z "${ADMIN_SECRET_KEY:-}" ]; then
+  echo "Error: ADMIN_SECRET_KEY must be set in .env" >&2
+  exit 1
+fi
+
+echo "==> Building contracts for wasm32-unknown-unknown..."
+cargo build --target wasm32-unknown-unknown --release
+
+# Setup network in CLI if it's local
+if [ "$NETWORK" = "local" ]; then
+  RPC_URL="${RPC_URL:-http://localhost:8000/soroban/rpc}"
+  if ! stellar network list | grep -q "^local$"; then
+    echo "==> Configuring local network in Stellar CLI..."
+    stellar network add --global local \
+      --rpc-url "$RPC_URL" \
+      --network-passphrase "Standalone Network ; Submissions Let's Play"
+  fi
+fi
+
+# Determine SAC Token Address
+if [ -n "${SAC_TOKEN_ADDRESS:-}" ]; then
+  USED_SAC_TOKEN_ADDRESS="$SAC_TOKEN_ADDRESS"
+else
+  echo "==> SAC_TOKEN_ADDRESS not set. Auto-deploying/wrapping native XLM token..."
+  if [ "$NETWORK" = "local" ]; then
+    echo "    Funding admin account via local friendbot..."
+    ADMIN_ADDR=$(stellar keys address "$ADMIN_SECRET_KEY")
+    curl -sf "http://localhost:8000/friendbot?addr=$ADMIN_ADDR" >/dev/null || true
+  fi
+  USED_SAC_TOKEN_ADDRESS=$(stellar contract asset deploy \
+    --asset native \
+    --source "$ADMIN_SECRET_KEY" \
+    --network "$NETWORK")
+  echo "    Wrapped Native SAC Token Address: $USED_SAC_TOKEN_ADDRESS"
+fi
+
+echo "==> Deploying treasury..."
+TREASURY_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/treasury.wasm \
+    --source "$ADMIN_SECRET_KEY" \
+    --network "$NETWORK")
+echo "    Treasury ID: $TREASURY_ID"
+
+echo "==> Deploying relay-registry..."
+REGISTRY_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/relay_registry.wasm \
+    --source "$ADMIN_SECRET_KEY" \
+    --network "$NETWORK")
+echo "    Relay Registry ID: $REGISTRY_ID"
+
+echo "==> Deploying fee-distributor..."
+FEE_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/fee_distributor.wasm \
+    --source "$ADMIN_SECRET_KEY" \
+    --network "$NETWORK")
+echo "    Fee Distributor ID: $FEE_ID"
+
+echo "==> Deploying dispute-resolver..."
+DISPUTE_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/dispute_resolver.wasm \
+    --source "$ADMIN_SECRET_KEY" \
+    --network "$NETWORK")
+echo "    Dispute Resolver ID: $DISPUTE_ID"
+
+# Save deployed addresses
+cat > "$SCRIPT_DIR/.deployed-addresses.env" <<EOF
+TREASURY_ID=$TREASURY_ID
+REGISTRY_ID=$REGISTRY_ID
+FEE_ID=$FEE_ID
+DISPUTE_ID=$DISPUTE_ID
+SAC_TOKEN_ADDRESS=$USED_SAC_TOKEN_ADDRESS
+EOF
+
+echo "==> All contracts deployed successfully."
+echo "    Addresses written to $SCRIPT_DIR/.deployed-addresses.env"

--- a/scripts/initialize-all.sh
+++ b/scripts/initialize-all.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# initialize-all.sh
+# StellarConduit Contracts — Automated Initialization Script
+# =============================================================================
+set -euo pipefail
+
+# Load config
+SCRIPT_DIR=$(dirname "$0")
+ENV_FILE="$SCRIPT_DIR/.env"
+DEPLOYED_FILE="$SCRIPT_DIR/.deployed-addresses.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Error: $ENV_FILE not found." >&2
+  exit 1
+fi
+if [ ! -f "$DEPLOYED_FILE" ]; then
+  echo "Error: $DEPLOYED_FILE not found. Run scripts/deploy-all.sh first." >&2
+  exit 1
+fi
+
+source "$ENV_FILE"
+source "$DEPLOYED_FILE"
+
+# Validate required variables
+if [ -z "${NETWORK:-}" ]; then
+  echo "Error: NETWORK must be set in .env" >&2
+  exit 1
+fi
+if [ -z "${ADMIN_SECRET_KEY:-}" ]; then
+  echo "Error: ADMIN_SECRET_KEY must be set in .env" >&2
+  exit 1
+fi
+if [ -z "${ADMIN_ADDRESS:-}" ]; then
+  echo "Error: ADMIN_ADDRESS must be set in .env" >&2
+  exit 1
+fi
+
+TOKEN_ADDRESS="${SAC_TOKEN_ADDRESS:-}"
+if [ -z "$TOKEN_ADDRESS" ]; then
+  echo "Error: SAC_TOKEN_ADDRESS is not set." >&2
+  exit 1
+fi
+
+# A helper function to invoke initialization command and check if already initialized
+invoke_and_initialize() {
+  local contract_name="$1"
+  local contract_id="$2"
+  local err_code="$3"
+  shift 3
+
+  echo "==> Initializing $contract_name..."
+  set +e
+  local output
+  output=$(stellar contract invoke \
+      --id "$contract_id" \
+      --source "$ADMIN_SECRET_KEY" \
+      --network "$NETWORK" \
+      -- "$@" 2>&1)
+  local status=$?
+  set -e
+
+  if [ $status -ne 0 ]; then
+    # Check if the output contains the specific contract error for AlreadyInitialized
+    if echo "$output" | grep -q -E "Error\(Contract, #$err_code\)|Error\(Contract, $err_code\)"; then
+      echo "    $contract_name is already initialized. Skipping."
+    else
+      echo "Error: Failed to initialize $contract_name" >&2
+      echo "$output" >&2
+      exit 1
+    fi
+  else
+    echo "    $contract_name initialized successfully."
+  fi
+}
+
+# 1. Initialize Treasury
+# Parameters: council: AdminCouncil, token_address: Address
+# AlreadyInitialized error code: 10
+invoke_and_initialize "treasury" "$TREASURY_ID" 10 \
+    initialize \
+    --council "{\"members\":[\"$ADMIN_ADDRESS\"],\"threshold\":1}" \
+    --token_address "$TOKEN_ADDRESS"
+
+# 2. Initialize Relay Registry
+# Parameters: council: AdminCouncil, token_address: Address, treasury_address: Address, min_stake: i128, stake_lock_period: u32
+# AlreadyInitialized error code: 10
+invoke_and_initialize "relay-registry" "$REGISTRY_ID" 10 \
+    initialize \
+    --council "{\"members\":[\"$ADMIN_ADDRESS\"],\"threshold\":1}" \
+    --token_address "$TOKEN_ADDRESS" \
+    --treasury_address "$TREASURY_ID" \
+    --min_stake 1000 \
+    --stake_lock_period 1000
+
+# 3. Initialize Fee Distributor
+# Parameters: council: AdminCouncil, fee_rate_bps: u32, treasury_share_bps: u32, treasury: Address, token: Address
+# AlreadyInitialized error code: 9
+invoke_and_initialize "fee-distributor" "$FEE_ID" 9 \
+    initialize \
+    --council "{\"members\":[\"$ADMIN_ADDRESS\"],\"threshold\":1}" \
+    --fee_rate_bps 50 \
+    --treasury_share_bps 2000 \
+    --treasury "$TREASURY_ID" \
+    --token "$TOKEN_ADDRESS"
+
+# 4. Initialize Dispute Resolver
+# Parameters: council: AdminCouncil, resolution_window: u32
+# AlreadyInitialized error code: 14
+invoke_and_initialize "dispute-resolver" "$DISPUTE_ID" 14 \
+    initialize \
+    --council "{\"members\":[\"$ADMIN_ADDRESS\"],\"threshold\":1}" \
+    --resolution_window 5000
+
+echo "==> All contracts initialized and wired."

--- a/scripts/register-relay-node.sh
+++ b/scripts/register-relay-node.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# register-relay-node.sh
+# StellarConduit Contracts — Register and Stake a Relay Node
+# =============================================================================
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <NODE_ADDRESS_OR_SECRET> <STAKE_AMOUNT> [REGION]" >&2
+  exit 1
+fi
+
+NODE_ARG="$1"
+STAKE_AMOUNT="$2"
+REGION="${3:-XX}"
+
+# Load config
+SCRIPT_DIR=$(dirname "$0")
+ENV_FILE="$SCRIPT_DIR/.env"
+DEPLOYED_FILE="$SCRIPT_DIR/.deployed-addresses.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Error: $ENV_FILE not found." >&2
+  exit 1
+fi
+if [ ! -f "$DEPLOYED_FILE" ]; then
+  echo "Error: $DEPLOYED_FILE not found. Run scripts/deploy-all.sh first." >&2
+  exit 1
+fi
+
+source "$ENV_FILE"
+source "$DEPLOYED_FILE"
+
+# Validate required variables
+if [ -z "${NETWORK:-}" ]; then
+  echo "Error: NETWORK must be set in .env" >&2
+  exit 1
+fi
+
+# Determine public key and secret key/signer
+NODE_SECRET=""
+NODE_PUBLIC=""
+
+if [[ "$NODE_ARG" =~ ^S[A-Z2-7]{55}$ ]]; then
+  # It's a secret key
+  NODE_SECRET="$NODE_ARG"
+  echo "==> Deriving public address from secret key..."
+  NODE_PUBLIC=$(stellar keys address "$NODE_SECRET")
+else
+  # It's a public key (G...)
+  NODE_PUBLIC="$NODE_ARG"
+  if [ "$NODE_PUBLIC" = "$ADMIN_ADDRESS" ]; then
+    NODE_SECRET="$ADMIN_SECRET_KEY"
+  elif [ -n "${NODE_SECRET_KEY:-}" ]; then
+    NODE_SECRET="$NODE_SECRET_KEY"
+  else
+    NODE_SECRET="$NODE_PUBLIC" # fall back to passing public key (works if loaded in CLI)
+  fi
+fi
+
+# Fund the node account if local or testnet to ensure it has native XLM (wrapped SAC token)
+echo "==> Checking node account funding state..."
+if [ "$NETWORK" = "local" ]; then
+  echo "    Funding account via local Friendbot..."
+  curl -sf "http://localhost:8000/friendbot?addr=$NODE_PUBLIC" >/dev/null || true
+elif [ "$NETWORK" = "testnet" ]; then
+  echo "    Funding account via Testnet Friendbot..."
+  curl -sf "https://friendbot.stellar.org/?addr=$NODE_PUBLIC" >/dev/null || true
+fi
+
+echo "==> Registering node $NODE_PUBLIC in region $REGION..."
+set +e
+output=$(stellar contract invoke \
+  --id "$REGISTRY_ID" \
+  --source "$NODE_SECRET" \
+  --network "$NETWORK" \
+  -- register \
+  --node_address "$NODE_PUBLIC" \
+  --metadata "{\"region\":\"$REGION\",\"capacity\":1000,\"uptime_commitment\":95}" 2>&1)
+status=$?
+set -e
+
+if [ $status -ne 0 ]; then
+  # AlreadyRegistered error code: 2
+  if echo "$output" | grep -q -E "Error\(Contract, #2\)|Error\(Contract, 2\)"; then
+    echo "    Node $NODE_PUBLIC is already registered. Skipping registration."
+  else
+    echo "Error: Failed to register node $NODE_PUBLIC" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+else
+  echo "    Node $NODE_PUBLIC registered successfully."
+fi
+
+echo "==> Staking $STAKE_AMOUNT tokens..."
+stellar contract invoke \
+  --id "$REGISTRY_ID" \
+  --source "$NODE_SECRET" \
+  --network "$NETWORK" \
+  -- stake \
+  --node_address "$NODE_PUBLIC" \
+  --amount "$STAKE_AMOUNT"
+
+echo "==> Node $NODE_PUBLIC is now Active with stake $STAKE_AMOUNT."

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run-integration-tests.sh
+# StellarConduit Contracts — E2E Sandbox Test Runner
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$0")
+
+echo "==> Starting Stellar Quickstart (local sandbox)..."
+# Pull and run the quickstart container
+docker run --rm -d \
+    --name stellar-sandbox \
+    -p 8000:8000 \
+    stellar/quickstart:latest --local --enable-soroban-rpc
+
+# Helper to stop sandbox on exit
+cleanup() {
+  echo "==> Cleaning up..."
+  docker stop stellar-sandbox || true
+  rm -f "$SCRIPT_DIR/.env" "$SCRIPT_DIR/.deployed-addresses.env"
+}
+trap cleanup EXIT
+
+# Wait for RPC to be ready
+echo "==> Waiting for local RPC to be ready..."
+until curl -sf http://localhost:8000/soroban/rpc >/dev/null; do
+  echo "    RPC not ready yet, sleeping 2 seconds..."
+  sleep 2
+done
+echo "==> RPC is ready!"
+
+# Configure network in Stellar CLI
+echo "==> Configuring local network in Stellar CLI..."
+stellar network add --global local \
+  --rpc-url http://localhost:8000/soroban/rpc \
+  --network-passphrase "Standalone Network ; Submissions Let's Play"
+
+# Generate and fund local-admin identity
+echo "==> Generating and funding local-admin identity..."
+stellar keys generate --global local-admin --network local
+
+export NETWORK=local
+export ADMIN_SECRET_KEY=local-admin
+export ADMIN_ADDRESS=$(stellar keys address local-admin)
+export RPC_URL=http://localhost:8000/soroban/rpc
+export HORIZON_URL=http://localhost:8000
+
+# Create a temporary scripts/.env for deployment/initialize scripts to source
+echo "==> Writing temporary scripts/.env for local deployment..."
+cat > "$SCRIPT_DIR/.env" <<EOF
+NETWORK=$NETWORK
+ADMIN_SECRET_KEY=$ADMIN_SECRET_KEY
+ADMIN_ADDRESS=$ADMIN_ADDRESS
+SAC_TOKEN_ADDRESS=
+RPC_URL=$RPC_URL
+HORIZON_URL=$HORIZON_URL
+EOF
+
+echo "==> Deploying contracts to local sandbox..."
+bash "$SCRIPT_DIR/deploy-all.sh"
+
+echo "==> Initializing contracts..."
+bash "$SCRIPT_DIR/initialize-all.sh"
+
+echo "==> Running cargo test..."
+cargo test -- --include-ignored
+
+echo "==> Integration tests complete."

--- a/tests/integration/full-settlement-flow-test.rs
+++ b/tests/integration/full-settlement-flow-test.rs
@@ -94,12 +94,7 @@ fn setup_all<'a>() -> (
 		threshold: 1,
 	};
 	// min_stake = 100, stake_lock_period = 10 ledgers
-	relay_client.initialize(&relay_council, &100i128, &10u32);
-
-	// Set token address in relay registry storage (init doesn't take token address)
-	env.as_contract(&relay_client.address, || {
-		relay_registry::storage::set_token_address(&env, &token_id);
-	});
+	relay_client.initialize(&relay_council, &token_id, &treasury_id, &100i128, &10u32);
 
 	// Deploy dispute resolver and initialize
 	let dispute_id = env.register(dispute_resolver::DisputeResolverContract, ());

--- a/tests/relay-registry-test.rs
+++ b/tests/relay-registry-test.rs
@@ -39,8 +39,11 @@ mod tests {
             threshold: 1,
         };
         
+        let token_address = Address::generate(&env);
+        let treasury_address = Address::generate(&env);
+        
         // Initialize with test parameters
-        client.initialize(&council, &100i128, &10u32);
+        client.initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
         
         (env, client, admin)
     }
@@ -79,8 +82,11 @@ mod tests {
             threshold: 1,
         };
         
+        let token_address = Address::generate(&env);
+        let treasury_address = Address::generate(&env);
+        
         // Test successful initialization
-        let result = client.try_initialize(&council, &100i128, &10u32);
+        let result = client.try_initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
         assert_eq!(result, Ok(()));
         
         // Verify initialization was successful by trying to register a node
@@ -106,8 +112,11 @@ mod tests {
             threshold: 1,
         };
         
+        let token_address = Address::generate(&env);
+        let treasury_address = Address::generate(&env);
+        
         // Test that second initialization fails
-        let result = client.try_initialize(&council, &200i128, &20u32);
+        let result = client.try_initialize(&council, &token_address, &treasury_address, &200i128, &20u32);
         assert_eq!(result, Err(ContractError::AlreadyInitialized));
     }
 
@@ -127,8 +136,11 @@ mod tests {
             threshold: 1,
         };
         
+        let token_address = Address::generate(&env);
+        let treasury_address = Address::generate(&env);
+        
         // Test that zero min_stake fails
-        let result = client.try_initialize(&council, &0i128, &10u32);
+        let result = client.try_initialize(&council, &token_address, &treasury_address, &0i128, &10u32);
         assert_eq!(result, Err(ContractError::InvalidAmount));
     }
 
@@ -148,8 +160,11 @@ mod tests {
             threshold: 1,
         };
         
+        let token_address = Address::generate(&env);
+        let treasury_address = Address::generate(&env);
+        
         // Test that zero lock period fails
-        let result = client.try_initialize(&council, &100i128, &0u32);
+        let result = client.try_initialize(&council, &token_address, &treasury_address, &100i128, &0u32);
         assert_eq!(result, Err(ContractError::InvalidAmount));
     }
 
@@ -169,8 +184,11 @@ mod tests {
             threshold: 2, // Threshold > members count
         };
         
+        let token_address = Address::generate(&env);
+        let treasury_address = Address::generate(&env);
+        
         // Test that invalid council config fails
-        let result = client.try_initialize(&council, &100i128, &10u32);
+        let result = client.try_initialize(&council, &token_address, &treasury_address, &100i128, &10u32);
         assert_eq!(result, Err(ContractError::InvalidCouncilConfig));
     }
 


### PR DESCRIPTION
## closes #127

- Add deploy-all.sh, initialize-all.sh, register-relay-node.sh, run-integration-tests.sh
- Add .env.example template for deployment configuration
- Update relay-registry initialize() to accept token_address and treasury_address
- Add cdylib crate-type to treasury Cargo.toml for WASM compilation
- Update unit and integration tests for new initialize signature
- Add integration-test CI job to ci.yml
- Update deployment-guide.md with automated script usage
- Add scripts/*.env to .gitignore